### PR TITLE
Override runtimepath when running tests

### DIFF
--- a/.busted
+++ b/.busted
@@ -2,7 +2,7 @@ return {
   _all = {
     coverage = true,
     lpath = "lua/?.lua;lua/?/init.lua",
-    lua = "nlua",
+    lua = [[nlua -e 'vim.o.rtp = "."']],
     verbose = true,
   },
 }

--- a/.luacov
+++ b/.luacov
@@ -1,13 +1,3 @@
--- Include telescope_cycler modules in coverage report
-modules = {
-    ["telescope_cycler"] = "lua/telescope_cycler/init.lua",
-}
-
--- Include spec modules in coverage report
-include = {
-    "spec",
-}
-
 -- Exclude fixtures and spec helpers from coverage report
 exclude = {
     ".luarocks",


### PR DESCRIPTION
It seems that with the plugin installed in your neovim installation, it gets loaded from there instead of the dev repo when running the tests. Modifying the `nlua` commandline to set the runtime path to `"."` fixes it.